### PR TITLE
Fix: duplicated errors when `perform_request` is rescued

### DIFF
--- a/app/services/decidim/verifications/sant_boi_census/sant_boi_census_authorization_handler.rb
+++ b/app/services/decidim/verifications/sant_boi_census/sant_boi_census_authorization_handler.rb
@@ -42,7 +42,7 @@ module Decidim
 
           @response = perform_request
 
-          errors.add(:base, I18n.t("cannot_validate", scope: "errors.messages.sant_boi_census_authorization_handler")) unless @response[:status] == 200
+          errors.add(:base, I18n.t("connection_failed", scope: "errors.messages.sant_boi_census_authorization_handler")) unless @response[:status] == 200
         end
 
         # Validates the document against the Sant Boi WS.
@@ -82,8 +82,6 @@ module Decidim
         #   status => WS response status, as Integer
         def perform_request
           SantBoiCensusAuthorizationService.new(sanitized_document_type, document_number).perform_request
-        rescue StandardError
-          errors.add(:base, I18n.t("connection_failed", scope: "errors.messages.sant_boi_census_authorization_handler"))
         end
 
         # Returns true or false depending on whether XML element 'HABITANTE' is found.

--- a/app/services/decidim/verifications/sant_boi_census/sant_boi_census_authorization_service.rb
+++ b/app/services/decidim/verifications/sant_boi_census/sant_boi_census_authorization_service.rb
@@ -20,17 +20,19 @@ module Decidim
         #   body   => WS response body, as Nokogiri::XML instance
         #   status => WS response status, as Integer
         def perform_request
-          return @response if defined?(@response)
-
           @token = retrieve_login_response(perform_login_request.body)
+
           response = perform_do_operation_tao_request
 
-          @response = { status: response.status,
-                        body: retrieve_get_habitante_by_dni_response(response.body) }
+          {
+            status: response.status,
+            body: retrieve_get_habitante_by_dni_response(response.body)
+          }
         rescue StandardError => e
           Rails.logger.error "[#{self.class.name}] Failed to perform request"
           Rails.logger.error e.message
           Rails.logger.error e.backtrace.join("\n")
+          {} # To avoid crashing in SantBoiCensusAuthorizationHandler::ws_request_must_succeed
         end
 
         private

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -17,8 +17,6 @@ ca:
   errors:
     messages:
       sant_boi_census_authorization_handler:
-        cannot_validate: El cens de Sant Boi no pot validar les seves dades. No es
-          compleixen les condicions addicionals per verificar-se
         connection_failed: No es possible connectar amb el cens de Sant Boi. Si us
           plau, intenti-ho més tard.
         document_number_not_valid: El document d'identitat no és vàlid

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,8 +17,6 @@ en:
   errors:
     messages:
       sant_boi_census_authorization_handler:
-        cannot_validate: The census of Sant Boi cannot validate your data. The additional
-          conditions to be verified are not met.
         connection_failed: It is not possible to connect with the Sant Boi census.
           Please try again later.
         document_number_not_valid: The document number is not valid

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,8 +17,6 @@ es:
   errors:
     messages:
       sant_boi_census_authorization_handler:
-        cannot_validate: El censo de Sant Boi no puede validar sus datos. No se cumplen
-          las condiciones adicionales para verificarse
         connection_failed: No es posible conectar con el censo de Sant Boi. Por favor,
           inténtelo más tarde.
         document_number_not_valid: El documento de identidad no es válido


### PR DESCRIPTION
If `perform_request` method was not rescued but `ws_request_must_succeed` validation failed, the following error was added:

> El cens de  Sant Boi no pot validar les seves dades. No es compleixen les condicions addicionals per verificar-se

If `perform_request` method was rescued, which then caused  `ws_request_must_succeed` validation to fail, then two messages were added:

![duplicated_error](https://user-images.githubusercontent.com/40306853/60259382-6d42dd80-98d7-11e9-8bc3-c3f7f225e386.png)
